### PR TITLE
Sam erik/card moleculex

### DIFF
--- a/frontend/src/components/molecules/card/ProviderCard.tsx
+++ b/frontend/src/components/molecules/card/ProviderCard.tsx
@@ -1,18 +1,16 @@
 import "./ProviderCard.scss";
 
-export type AvailabilitySlot = {
+export type Availability= {
   day: string;
   time: string;
 };
-
-export type Availability = AvailabilitySlot[];
 
 export type ProviderCardProps = {
   name: string;
   rating: number;
   field: string;
   location: string;
-  availability: Availability;
+  availability: Availability[];
   insurance: string[];
   number: number;
   about: string;

--- a/frontend/src/components/molecules/card/ProviderCard.tsx
+++ b/frontend/src/components/molecules/card/ProviderCard.tsx
@@ -1,0 +1,67 @@
+import "./ProviderCard.scss";
+
+export type AvailabilitySlot = {
+  day: string;
+  time: string;
+};
+
+export type Availability = AvailabilitySlot[];
+
+export type ProviderCardProps = {
+  name: string;
+  rating: number;
+  field: string;
+  location: string;
+  availability: Availability;
+  insurance: string[];
+  number: number;
+  about: string;
+  experience: string;
+};
+
+const ProviderCard = ({
+  name,
+  rating,
+  field,
+  location,
+  availability,
+  insurance,
+  number,
+  about,
+  experience,
+}: ProviderCardProps) => {
+  return (
+    <div className="provider-card">
+      <h2 className="provider-card__name">{name}</h2>
+      <p className="provider-card__rating">Rating: {rating}</p>
+      <p className="provider-card__field">Field: {field}</p>
+      <p className="provider-card__location">Location: {location}</p>
+
+      <div className="provider-card__availability">
+        <h3>Availability</h3>
+        <ul>
+          {availability.map((slot, index) => (
+            <li key={index}>
+              {slot.day}: {slot.time}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="provider-card__insurance">
+        <h3>Insurance</h3>
+        <ul>
+          {insurance.map((item, index) => (
+            <li key={index}>{item}</li>
+          ))}
+        </ul>
+      </div>
+
+      <p className="provider-card__number">Phone: {number}</p>
+      <p className="provider-card__about">{about}</p>
+      <p className="provider-card__experience">Experience: {experience}</p>
+    </div>
+  );
+};
+
+export default ProviderCard;

--- a/frontend/src/components/molecules/card/ProviderCard.tsx
+++ b/frontend/src/components/molecules/card/ProviderCard.tsx
@@ -31,13 +31,13 @@ const ProviderCard = ({
   experience,
 }: ProviderCardProps) => {
   return (
-    <div className="provider-card">
-      <h2 className="provider-card__name">{name}</h2>
-      <p className="provider-card__rating">Rating: {rating}</p>
-      <p className="provider-card__field">Field: {field}</p>
-      <p className="provider-card__location">Location: {location}</p>
+    <div className="providerCard providerCard--provider">
+      <h2 className="providerCard__name">{name}</h2>
+      <p className="providerCard__rating">Rating: {rating}</p>
+      <p className="providerCard__field">Field: {field}</p>
+      <p className="providerCard__location">Location: {location}</p>
 
-      <div className="provider-card__availability">
+      <div className="providerCard__availability">
         <h3>Availability</h3>
         <ul>
           {availability.map((slot, index) => (
@@ -48,7 +48,7 @@ const ProviderCard = ({
         </ul>
       </div>
 
-      <div className="provider-card__insurance">
+      <div className="providerCard__insurance">
         <h3>Insurance</h3>
         <ul>
           {insurance.map((item, index) => (
@@ -57,9 +57,9 @@ const ProviderCard = ({
         </ul>
       </div>
 
-      <p className="provider-card__number">Phone: {number}</p>
-      <p className="provider-card__about">{about}</p>
-      <p className="provider-card__experience">Experience: {experience}</p>
+      <p className="providerCard__number">Phone: {number}</p>
+      <p className="providerCard__about">{about}</p>
+      <p className="providerCard__experience">Experience: {experience}</p>
     </div>
   );
 };


### PR DESCRIPTION
## Overview
This PR implements the basic shell for the `ProviderCard` molecule under `frontend/src/components/molecules/card/ProviderCard/`.

## Changes made
- Added `ProviderCard.tsx`
- Added `ProviderCard.scss`
- Defined `ProviderCardProps` with proper TypeScript typings
- Defined custom availability types:
  - `Availability`
- Rendered all required provider fields from props:
  - `name`
  - `rating`
  - `field`
  - `location`
  - `availability`
  - `insurance`
  - `number`
  - `about`
  - `experience`

## Additional details
- The SCSS file is included and left empty

## Testing
- Verified the component uses proper TypeScript types for all props