### PR TITLE
Provider Card UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
         "firebase": "^12.9.0",
+        "lucide-react": "^1.7.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^7.13.1",
@@ -16449,6 +16450,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lusca": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "firebase": "^12.9.0",
+    "lucide-react": "^1.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.13.1",

--- a/frontend/src/components/atoms/Button/Button.scss
+++ b/frontend/src/components/atoms/Button/Button.scss
@@ -1,0 +1,27 @@
+.button {
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+
+
+.button--rect {
+  background: #d9d9d9;
+  color: #000000;
+  border-radius: 12px;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1.2;
+  padding: 10px 20px;
+  transition: filter 0.15s ease;
+}
+
+.button--rect:hover {
+  filter: brightness(0.97);
+}

--- a/frontend/src/components/atoms/Button/Button.tsx
+++ b/frontend/src/components/atoms/Button/Button.tsx
@@ -3,7 +3,7 @@ import "./Button.scss";
 
 interface ButtonProps {
   children: React.ReactNode;
-  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   variant?: string;
   disabled?: boolean;
 }
@@ -17,7 +17,7 @@ function Button({
   return (
     <button
       className={`button button--${variant}`}
-      onClick={(e) => onClick(e)}
+      onClick={(e) => onClick?.(e)}
       disabled={disabled}
     >
       {children}

--- a/frontend/src/components/molecules/card/ProviderCard.scss
+++ b/frontend/src/components/molecules/card/ProviderCard.scss
@@ -1,0 +1,129 @@
+.providerCard {
+  width: min(100%, 500px);
+  background: #ffffff;
+  border: 1px solid #c8c8c8;
+  border-radius: 16px;
+  padding: 24px;
+  color: #000000;
+}
+
+.providerCard__header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.providerCard__avatarImage,
+.providerCard__avatarFallback {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  object-fit: cover;
+}
+
+.providerCard__avatarFallback {
+  background: #d2d2d2;
+}
+
+.providerCard__nameGroup {
+  min-width: 0;
+}
+
+.providerCard__name {
+  margin: 0;
+  font-size: 22px;
+  line-height: 1.2;
+  font-weight: 700;
+}
+
+.providerCard__field {
+  margin: 4px 0 0;
+  font-size: 14px;
+  font-weight: 500;
+  color: #000000;
+}
+
+.providerCard__infoGrid {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  margin-bottom: 20px;
+}
+
+.providerCard__infoColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.providerCard__infoRow {
+  margin: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: #000000;
+
+  svg {
+    flex-shrink: 0;
+    margin-top: 2px;
+  }
+}
+
+.providerCard__insurance {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.providerCard__insuranceBadge {
+  background: #e0e0e0;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #000000;
+  line-height: 1.4;
+}
+
+.providerCard__footer {
+  display: flex;
+  gap: 12px;
+}
+
+.providerCard__footer .button {
+  min-height: 48px;
+  border-radius: 12px;
+}
+
+.providerCard__footer .button:first-child {
+  flex: 1;
+}
+
+.providerCard__footer .button:last-child {
+  min-width: 80px;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+@media (max-width: 500px) {
+  .providerCard {
+    padding: 16px;
+  }
+
+  .providerCard__infoGrid {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .providerCard__footer {
+    gap: 8px;
+  }
+}

--- a/frontend/src/components/molecules/card/ProviderCard.tsx
+++ b/frontend/src/components/molecules/card/ProviderCard.tsx
@@ -1,64 +1,95 @@
 import "./ProviderCard.scss";
+import Button from "../../atoms/Button/Button";
+import { MapPin, Phone, Calendar, Shield } from "lucide-react";
 
-export type Availability= {
+export type Availability = {
   day: string;
   time: string;
 };
 
 export type ProviderCardProps = {
   name: string;
-  rating: number;
   field: string;
   location: string;
   availability: Availability[];
   insurance: string[];
-  number: number;
+  number: string;
   about: string;
   experience: string;
+  imageUrl?: string;
 };
 
 const ProviderCard = ({
   name,
-  rating,
   field,
   location,
   availability,
   insurance,
   number,
-  about,
-  experience,
+  imageUrl,
 }: ProviderCardProps) => {
   return (
-    <div className="providerCard providerCard--provider">
-      <h2 className="providerCard__name">{name}</h2>
-      <p className="providerCard__rating">Rating: {rating}</p>
-      <p className="providerCard__field">Field: {field}</p>
-      <p className="providerCard__location">Location: {location}</p>
+    <article className="providerCard">
+      <div className="providerCard__header">
+        <div className="providerCard__avatarWrapper">
+          {imageUrl ? (
+            <img className="providerCard__avatarImage" src={imageUrl} alt={`${name} profile`} />
+          ) : (
+            <div className="providerCard__avatarFallback" />
+          )}
+        </div>
 
-      <div className="providerCard__availability">
-        <h3>Availability</h3>
-        <ul>
-          {availability.map((slot, index) => (
-            <li key={index}>
-              {slot.day}: {slot.time}
-            </li>
-          ))}
-        </ul>
+        <div className="providerCard__nameGroup">
+          <h2 className="providerCard__name">{name}</h2>
+          <p className="providerCard__field">{field}</p>
+        </div>
       </div>
 
-      <div className="providerCard__insurance">
-        <h3>Insurance</h3>
-        <ul>
-          {insurance.map((item, index) => (
-            <li key={index}>{item}</li>
-          ))}
-        </ul>
+      <div className="providerCard__infoGrid">
+        <div className="providerCard__infoColumn">
+          <p className="providerCard__infoRow">
+            <MapPin size={16} aria-hidden="true" />
+            <span>{location}</span>
+          </p>
+
+          <p className="providerCard__infoRow">
+            <Phone size={16} aria-hidden="true" />
+            <span>{number}</span>
+          </p>
+        </div>
+
+        <div className="providerCard__infoColumn">
+          <p className="providerCard__infoRow">
+            <Calendar size={16} aria-hidden="true" />
+            <span>
+              {availability.map((slot, i) => (
+                <span key={i}>{slot.day}, {slot.time}{i < availability.length - 1 ? " | " : ""}</span>
+              ))}
+            </span>
+          </p>
+
+          <p className="providerCard__infoRow">
+            <Shield size={16} aria-hidden="true" />
+            <span className="providerCard__insurance">
+              {insurance.map((item) => (
+                <span className="providerCard__insuranceBadge" key={item}>
+                  {item}
+                </span>
+              ))}
+            </span>
+          </p>
+        </div>
       </div>
 
-      <p className="providerCard__number">Phone: {number}</p>
-      <p className="providerCard__about">{about}</p>
-      <p className="providerCard__experience">Experience: {experience}</p>
-    </div>
+      <div className="providerCard__footer">
+        <Button variant="rect">
+          Book Appointment
+        </Button>
+        <Button variant="rect">
+          More
+        </Button>
+      </div>
+    </article>
   );
 };
 

--- a/frontend/src/components/pages/providers/index.tsx
+++ b/frontend/src/components/pages/providers/index.tsx
@@ -1,11 +1,19 @@
+import ProviderCard from "../../molecules/card/ProviderCard";
 const Providers: React.FC = () => {
-
-    return (
-        <div className="providers">
-            <p>👩‍⚕️</p>
-        </div>
-    )
-
-}
+  return (
+    <div className="providers p-6 flex justify-center">
+      <ProviderCard
+        name="NAME"
+        field="Counseling & Psychology"
+        location="110 Ho Plaza, Ithaca, NY"
+        availability={[{ day: "Mon-Sat", time: "8 AM - 8 PM" }]}
+        insurance={["Cornell SHP", "Self-pay"]}
+        number="123-456-7890"
+        about="On-campus support for all Cornell students."
+        experience="Experienced in crisis intervention and long-term therapy."
+      />
+    </div>
+  );
+};
 
 export default Providers;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7243,6 +7243,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lucide-react@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz"
+  integrity sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==
+
 lusca@1.6.1:
   version "1.6.1"
   resolved "https://registry.npmjs.org/lusca/-/lusca-1.6.1.tgz"
@@ -8787,7 +8792,7 @@ react-scripts@5.0.1:
   optionalDependencies:
     fsevents "^2.3.2"
 
-react@^18.0.0, react@^18.2.0, "react@>= 16", react@>=18:
+"react@^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", react@^18.0.0, react@^18.2.0, "react@>= 16", react@>=18:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==


### PR DESCRIPTION
**What was done**
- Implemented `ProviderCard` molecule based on Figma
- Displays name, field, location, phone, availability, and insurance
- Added image support with fallback circle
- Used `Button` atom with `variant="rect"` for actions

**Testing**
- Ran `npm start` in frontend
- Verified on `/providers` page

**Preview**
<img width="569" height="358" alt="Screenshot 2026-04-08 at 2 26 45 PM" src="https://github.com/user-attachments/assets/e54e3e17-676c-4783-bc59-f39324120df4" />

Closes #15 